### PR TITLE
Fix coercion of lists to vector.

### DIFF
--- a/array.lisp
+++ b/array.lisp
@@ -63,7 +63,7 @@
          (el-type (element-type cffi-null-array)))
     (do ((i 0 (+ i 1))) ((null-pointer-p (mem-aref ptr :pointer i)))
       (push (mem-aref ptr el-type i) res))
-    (coerce (nreverse res) 'array)))
+    (coerce (nreverse res) 'vector)))
 
 (defctype string-array (null-array :string) "Zero-terminated string array")
 


### PR DESCRIPTION
(coerce list 'array) doesn't work, as ARRAY is not a subtype of VECTOR.